### PR TITLE
Rename tables to remove prefix `config_`. Closes #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ select
   key,
   value
 from
-  config_ini;
+  ini_key_value;
 ```
 
 ```sql
@@ -46,13 +46,13 @@ select
   key,
   value
 from
-  config_ini
+  ini_key_value
 where
-  path = ;
+  path = '/Users/myuser/ini/defaults.ini';
 ```
 
 ```sh
-> select section, key, value from config_ini where section = 'Settings';
+> select section, key, value from ini_key_value where section = 'Settings';
 +----------+---------------+-------------------------------------------+
 | section  | key           | value                                     |
 +----------+---------------+-------------------------------------------+

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ from
   ini_key_value;
 ```
 
+or, you can query configurations of a particular file using:
+
 ```sql
 select
   path,

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,11 +25,11 @@ select
   key,
   value
 from
-  config_ini;
+  ini_key_value;
 ```
 
 ```sh
-> select section, key, value from config_ini where section = 'Settings';
+> select section, key, value from ini_key_value where section = 'Settings';
 +----------+---------------+-------------------------------------------+
 | section  | key           | value                                     |
 +----------+---------------+-------------------------------------------+

--- a/docs/tables/ini_key_value.md
+++ b/docs/tables/ini_key_value.md
@@ -1,4 +1,4 @@
-# Table: config_ini_key_value
+# Table: ini_key_value
 
 Query section and key-value pair data from INI files found in the configured `paths`.
 
@@ -16,7 +16,7 @@ select
   value,
   comment
 from
-  config_ini_key_value;
+  ini_key_value;
 ```
 
 ```sh
@@ -50,7 +50,7 @@ select
   value,
   comment
 from
-  config_ini_key_value
+  ini_key_value
 where
   path = '/Users/myuser/ini/defaults.ini';
 ```
@@ -87,7 +87,7 @@ select
   key,
   value
 from
-  config_ini_key_value
+  ini_key_value
 where
   path = '/Users/myuser/ini/defaults.ini';
 ```
@@ -111,7 +111,7 @@ select
   key,
   value
 from
-  config_ini_key_value
+  ini_key_value
 where
   path = '/Users/myuser/ini/defaults.ini'
   and section = 'analytics'
@@ -127,7 +127,7 @@ select
   key,
   value::bool
 from
-  config_ini_key_value
+  ini_key_value
 where
   path = '/Users/myuser/ini/defaults.ini'
   and section = 'analytics'
@@ -171,7 +171,7 @@ select
   key,
   value
 from
-  config_ini_key_value
+  ini_key_value
 where
   path = '/Users/myuser/ini/defaults.ini';
 ```

--- a/docs/tables/ini_key_value.md
+++ b/docs/tables/ini_key_value.md
@@ -11,6 +11,7 @@ This table will retrieve all key-value pairs from each file mentioned above, alo
 
 ```sql
 select
+  path,
   section,
   key,
   value,

--- a/docs/tables/ini_section.md
+++ b/docs/tables/ini_section.md
@@ -1,4 +1,4 @@
-# Table: config_ini_section
+# Table: ini_section
 
 Retrieves all sections defined in an INI file.
 
@@ -12,7 +12,7 @@ select
   section,
   comment
 from
-  config_ini_section
+  ini_section;
 ```
 
 ### List sections for a specific file
@@ -23,7 +23,7 @@ select
   section,
   comment
 from
-  config_ini_section
+  ini_section
 where
   path = '/Users/myuser/configs/main.ini';
 ```
@@ -36,7 +36,7 @@ select
   section,
   comment
 from
-  config_ini_section
+  ini_section
 where
   section like 'settings.%';
 ```

--- a/tables/plugin.go
+++ b/tables/plugin.go
@@ -22,8 +22,8 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 		DefaultTransform: transform.FromCamel().NullIfZero(),
 		SchemaMode:       plugin.SchemaModeDynamic,
 		TableMap: map[string]*plugin.Table{
-			"config_ini_key_value": tableConfigINIKeyValue(ctx),
-			"config_ini_section":   tableConfigINISection(ctx),
+			"ini_key_value": tableINIKeyValue(ctx),
+			"ini_section":   tableINISection(ctx),
 		},
 	}
 	return p

--- a/tables/table_ini_key_value.go
+++ b/tables/table_ini_key_value.go
@@ -13,9 +13,9 @@ import (
 	"github.com/turbot/steampipe-plugin-sdk/plugin"
 )
 
-func tableConfigINIKeyValue(ctx context.Context) *plugin.Table {
+func tableINIKeyValue(ctx context.Context) *plugin.Table {
 	return &plugin.Table{
-		Name:        "config_ini_key_value",
+		Name:        "ini_key_value",
 		Description: "Table representation of an INI file.",
 		List: &plugin.ListConfig{
 			Hydrate: listINIWithPath,

--- a/tables/table_ini_section.go
+++ b/tables/table_ini_section.go
@@ -10,9 +10,9 @@ import (
 	"github.com/turbot/steampipe-plugin-sdk/plugin"
 )
 
-func tableConfigINISection(ctx context.Context) *plugin.Table {
+func tableINISection(ctx context.Context) *plugin.Table {
 	return &plugin.Table{
-		Name:        "config_ini_section",
+		Name:        "ini_section",
 		Description: "Retrieves a list of sections and subsections defined in a INI file.",
 		List: &plugin.ListConfig{
 			Hydrate: listINISections,


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
