### PR TITLE
Add support for json files which are arrays

### DIFF
--- a/tables/table_json_file.go
+++ b/tables/table_json_file.go
@@ -66,7 +66,8 @@ func listJSONFileWithPath(ctx context.Context, d *plugin.QueryData, h *plugin.Hy
 
 		byteValue, _ := ioutil.ReadAll(jsonFile)
 
-		var result map[string]interface{}
+		// Load either JSON objects or JSON arrays
+		var result interface{}
 		err = json.Unmarshal([]byte(byteValue), &result)
 		if err != nil {
 			plugin.Logger(ctx).Error("json_file.listJSONFileWithPath", "parse_error", err, "path", path)


### PR DESCRIPTION
Allows the config plugin to load JSON files which are arrays, rather than failing if _any json file in the current search path is an array_

**NB:** Retains default behaviour by only attempting array load if an error occurred whilst loading the json file as an object

# Example query results
<details>
  <summary>Results</summary>
  
**Input file: `test.json`**
```json
[
  { "test": "I am valid json" },
  { "test": "I am also valid json" }
]
```

**steampipe.io query and result:**
```
SELECT
  item ->> 'test' as test 
FROM
  json_file, 
  jsonb_array_elements(content) AS item
WHERE path LIKE '%test.json';

+----------------------+
| test                 |
+----------------------+
| I am valid json      |
| I am also valid json |
+----------------------+
```
</details>

Fixes turbot/steampipe-plugin-config#24