### PR TITLE
Fix config plugin using 100% CPU on load due to rogue dynamic schema definition. Closes #33

### DIFF
--- a/tables/plugin.go
+++ b/tables/plugin.go
@@ -15,7 +15,6 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			Schema:      ConfigSchema,
 		},
 		DefaultTransform: transform.FromCamel().NullIfZero(),
-		SchemaMode:       plugin.SchemaModeDynamic,
 		TableMap: map[string]*plugin.Table{
 			"ini_key_value":  tableINIKeyValue(ctx),
 			"ini_section":    tableINISection(ctx),


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
