### PR TITLE
fix: avoid `defer` in loops

### DIFF
--- a/tables/table_json_file.go
+++ b/tables/table_json_file.go
@@ -62,7 +62,9 @@ func listJSONFileWithPath(ctx context.Context, d *plugin.QueryData, h *plugin.Hy
 		}
 
 		byteValue, err := io.ReadAll(jsonFile)
-		jsonFile.Close()
+		if cerr := jsonFile.Close(); cerr != nil {
+			plugin.Logger(ctx).Error("json_file.listJSONFileWithPath", "close_error", cerr, "path", path)
+		}
 		if err != nil {
 			plugin.Logger(ctx).Error("json_file.listJSONFileWithPath", "read_error", err, "path", path)
 			return nil, fmt.Errorf("failed to read file content %s: %v", path, err)

--- a/tables/table_toml_file.go
+++ b/tables/table_toml_file.go
@@ -62,7 +62,9 @@ func listTOMLFileWithPath(ctx context.Context, d *plugin.QueryData, h *plugin.Hy
 		}
 
 		byteValue, err := io.ReadAll(tomlFile)
-		tomlFile.Close()
+		if cerr := tomlFile.Close(); cerr != nil {
+			plugin.Logger(ctx).Error("toml_file.listTOMLFileWithPath", "close_error", cerr, "path", path)
+		}
 		if err != nil {
 			plugin.Logger(ctx).Error("toml_file.listTOMLFileWithPath", "read_error", err, "path", path)
 			return nil, fmt.Errorf("failed to read file content %s: %v", path, err)


### PR DESCRIPTION
This PR is inspired by https://github.com/turbot/steampipe-plugin-config/pull/66#discussion_r2454125112.

The change consists of two parts:
- handling the case, where there is a read error,
- closing the opened file _manually_ (i.e without using `defer`).